### PR TITLE
UI Layer Enhancements: Back button behavior - Clear TextField on first press & then exit app on second press

### DIFF
--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/main/MainScreen.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/main/MainScreen.kt
@@ -1,5 +1,6 @@
 package net.techandgraphics.hymn.ui.screen.main
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
@@ -90,6 +91,11 @@ fun MainScreen(
   LaunchedEffect(state.onLangInvoke) {
     if (state.onLangInvoke) context.onTranslationChange(state.lang)
   }
+
+  BackHandler(enabled = state.searchQuery.trim().isNotEmpty()) {
+    onEvent(MainUiEvent.LyricUiEvent.ClearLyricUiQuery)
+  }
+
   val scrollState = rememberLazyListState()
   Scaffold(
     topBar = {


### PR DESCRIPTION
Fixes #151

### **Description**

This PR implements custom back button behavior:

- On the first press, if the `TextField` contains text, it is cleared. If the `TextField` is empty, the app prepares to exit.
- On the second press (after the `TextField` is empty), the app will exit.

This change ensures that the user can either clear the input or exit the app based on the state of the `TextField`.