### PR TITLE
Update Theme to Allow Custom Font Family Changes

### DIFF
--- a/app/src/main/java/net/techandgraphics/hymn/ui/theme/Theme.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/theme/Theme.kt
@@ -11,11 +11,11 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontFamily
 import androidx.core.view.WindowCompat
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 private val DarkColorScheme = darkColorScheme(
   primary = AccentColor,
@@ -43,6 +43,8 @@ fun HymnTheme(
   content: @Composable () -> Unit,
 
 ) {
+  val systemUiController = rememberSystemUiController()
+
   val colorScheme = when {
     dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
       val context = LocalContext.current
@@ -56,8 +58,11 @@ fun HymnTheme(
   if (!view.isInEditMode) {
     SideEffect {
       val window = (view.context as Activity).window
-      window.statusBarColor = colorScheme.primary.toArgb()
-      WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+      systemUiController.setSystemBarsColor(color = colorScheme.primary)
+      WindowCompat.getInsetsController(window, window.decorView).apply {
+        isAppearanceLightStatusBars = !darkTheme
+        isAppearanceLightNavigationBars = !darkTheme
+      }
     }
   }
 

--- a/app/src/main/java/net/techandgraphics/hymn/ui/theme/Type.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/theme/Type.kt
@@ -3,20 +3,66 @@ package net.techandgraphics.hymn.ui.theme
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.font.FontFamily
 
+private val dl = Typography().displayLarge
+private val dm = Typography().displayMedium
+private val ds = Typography().displaySmall
+private val hl = Typography().headlineLarge
+private val hm = Typography().headlineMedium
+private val hs = Typography().headlineSmall
+private val tl = Typography().titleLarge
+private val tm = Typography().titleMedium
+private val ts = Typography().titleSmall
+private val bl = Typography().bodyLarge
+private val bm = Typography().bodyMedium
+private val bs = Typography().bodySmall
+private val ll = Typography().labelLarge
+private val lm = Typography().labelMedium
+private val ls = Typography().labelSmall
+
 fun setTypography(fontFamily: FontFamily = FontFamily.Default) = Typography(
-  displayLarge = Typography().displayLarge.copy(fontFamily = fontFamily),
-  displayMedium = Typography().displayMedium.copy(fontFamily = fontFamily),
-  displaySmall = Typography().displaySmall.copy(fontFamily = fontFamily),
-  headlineLarge = Typography().headlineLarge.copy(fontFamily = fontFamily),
-  headlineMedium = Typography().headlineMedium.copy(fontFamily = fontFamily),
-  headlineSmall = Typography().headlineSmall.copy(fontFamily = fontFamily),
-  titleLarge = Typography().titleLarge.copy(fontFamily = fontFamily),
-  titleMedium = Typography().titleMedium.copy(fontFamily = fontFamily),
-  titleSmall = Typography().titleSmall.copy(fontFamily = fontFamily),
-  bodyLarge = Typography().bodyLarge.copy(fontFamily = fontFamily),
-  bodyMedium = Typography().bodyMedium.copy(fontFamily = fontFamily),
-  bodySmall = Typography().bodySmall.copy(fontFamily = fontFamily),
-  labelLarge = Typography().labelLarge.copy(fontFamily = fontFamily),
-  labelMedium = Typography().labelMedium.copy(fontFamily = fontFamily),
-  labelSmall = Typography().labelSmall.copy(fontFamily = fontFamily),
+  displayLarge = dl.copy(
+    fontFamily = fontFamily,
+  ),
+  displayMedium = dm.copy(
+    fontFamily = fontFamily,
+  ),
+  displaySmall = ds.copy(
+    fontFamily = fontFamily,
+  ),
+  headlineLarge = hl.copy(
+    fontFamily = fontFamily,
+  ),
+  headlineMedium = hm.copy(
+    fontFamily = fontFamily,
+  ),
+  headlineSmall = hs.copy(
+    fontFamily = fontFamily,
+  ),
+  titleLarge = tl.copy(
+    fontFamily = fontFamily,
+  ),
+  titleMedium = tm.copy(
+    fontFamily = fontFamily,
+  ),
+  titleSmall = ts.copy(
+    fontFamily = fontFamily,
+  ),
+  bodyLarge = bl.copy(
+    fontFamily = fontFamily,
+  ),
+  bodyMedium = bm.copy(
+    fontFamily = fontFamily,
+  ),
+  bodySmall = bs.copy(
+    fontFamily = fontFamily,
+  ),
+  labelLarge = ll.copy(
+    fontFamily = fontFamily,
+  ),
+  labelMedium = lm.copy(
+    fontFamily = fontFamily,
+  ),
+  labelSmall = ls.copy(
+    fontFamily = fontFamily,
+  )
 )


### PR DESCRIPTION
Fixes #167

###  Description
This PR updates the app's theme to allow for a customizable `fontFamily`. Now, you can easily change the font family across the entire app by modifying the theme.

#### Tasks:
1. Modify the `Typography` object in the theme to support a customizable `fontFamily`.
2. Apply the new `fontFamily` setting to all text-related components in the theme (`h1`, `h2`, `body1`, etc.).
3. Ensure that the custom font family is applied globally to all text elements in the app.
4. Test and verify that the font changes are applied consistently across all screens.