### PR TITLE
Fix Toolbar Top Margin Issue on Android 15 and Refactor FontDialog into Separate File

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools">
 
   <!--    <uses-permission android:name="android.permission.INTERNET" />-->
   <!--    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />-->
@@ -12,7 +13,9 @@
     android:label="@string/app_name"
     android:roundIcon="@mipmap/ic_launcher_round"
     android:supportsRtl="true"
-    android:theme="@style/Theme.App.Starting">
+    android:theme="@style/Theme.App.Starting"
+    android:windowSoftInputMode="adjustResize"
+    tools:targetApi="tiramisu">
     <activity
       android:name="net.techandgraphics.hymn.ui.activity.MainActivity"
       android:exported="true"

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/preview/FontSizeDialog.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/preview/FontSizeDialog.kt
@@ -1,0 +1,94 @@
+package net.techandgraphics.hymn.ui.screen.preview
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import net.techandgraphics.hymn.R
+import net.techandgraphics.hymn.ui.theme.HymnTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FontSizeDialog(
+  state: PreviewUiState,
+  onEvent: (PreviewUiEvent) -> Unit,
+  onDismissRequest: () -> Unit
+) {
+  Dialog(onDismissRequest = onDismissRequest) {
+    Card(
+      modifier = Modifier.padding(16.dp),
+      colors = CardDefaults.cardColors(
+        containerColor = MaterialTheme.colorScheme.surface
+      ),
+      elevation = CardDefaults.cardElevation(
+        defaultElevation = 1.dp
+      ),
+    ) {
+      Column(modifier = Modifier.padding(16.dp)) {
+        Text(
+          text = "Change lyrics font size",
+          modifier = Modifier.padding(start = 16.dp, top = 4.dp),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+          Slider(
+            value = state.fontSize.toFloat(),
+            onValueChange = { onEvent(PreviewUiEvent.FontSize(it.toInt())) },
+            valueRange = 1f..16f,
+            modifier = Modifier
+              .weight(1f)
+              .padding(end = 16.dp),
+            colors = SliderDefaults.colors(
+              thumbColor = MaterialTheme.colorScheme.primary,
+              activeTrackColor = MaterialTheme.colorScheme.primary,
+            ),
+            thumb = {
+              Icon(
+                painter = painterResource(id = R.drawable.ic_filled_circle),
+                contentDescription = null,
+                modifier = Modifier.size(32.dp),
+                tint = MaterialTheme.colorScheme.primary
+              )
+            },
+          )
+          Text(
+            text = state.fontSize.toString(),
+            modifier = Modifier.padding(end = 8.dp)
+          )
+        }
+      }
+    }
+  }
+}
+
+@Preview
+@Composable
+fun FontSizeDialogPreview() {
+  HymnTheme {
+    FontSizeDialog(
+      state = PreviewUiState(
+        fontSize = 10
+      ),
+      onEvent = {
+      }
+    ) {
+    }
+  }
+}

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/preview/PreviewScreen.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/preview/PreviewScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -181,8 +182,8 @@ fun PreviewScreen(
             )
           }
         },
-        modifier = Modifier
-          .shadow(elevation = 8.dp),
+        windowInsets = WindowInsets(top = 0.dp),
+        modifier = Modifier.shadow(elevation = 8.dp),
       )
     },
   ) { paddingValues ->


### PR DESCRIPTION
Fixes #169


### Description
There is a visual issue with the `Scaffold` toolbar where it has an unexpected top margin, particularly affecting devices running Android 15 (API level 21 or lower). This margin disrupts the layout, causing the toolbar to appear misaligned.

Additionally, the `FontDialog` component, which was previously embedded within other files, has been refactored into its own separate file to improve code organization and maintainability.

#### Checklist:
- [x] **Fix the Top Margin Issue**: Investigate and remove the unnecessary top margin on the `Scaffold` toolbar. Ensure that the toolbar displays correctly across different Android versions, especially Android 15 (API level 21).
- [x] **Refactor `FontDialog`**: Move the `FontDialog` component into its own separate file to improve modularity and readability of the codebase.
- [ ] **Test**: Verify that the top margin issue is fixed on Android 15, as well as on other devices. Also, ensure that the `FontDialog` continues to function correctly after the refactor.