### PR TITLE
Implement Toggle Functionality for Dynamic Color Theming

### DIFF
--- a/app/src/main/java/net/techandgraphics/hymn/data/prefs/DataStorePrefs.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/data/prefs/DataStorePrefs.kt
@@ -34,6 +34,7 @@ class DataStorePrefs @Inject constructor(
   val translationKey = context.getString(R.string.translation_key)
   val uniquelyCraftedKey = context.getString(R.string.uniquely_crafted_key)
   val uniquelyCraftedMills = context.getString(R.string.uniquely_crafted_mills_key)
+  val dynamicColorKey = context.getString(R.string.dynamic_color)
 
   val englishSuggestedForTheWeekKey = "suggestedForTheWeekKey"
   val chichewaSuggestedForTheWeekKey = "chichewaSuggestedForTheWeekKey"

--- a/app/src/main/java/net/techandgraphics/hymn/ui/activity/MainActivity.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/activity/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,11 +35,11 @@ class MainActivity : ComponentActivity() {
       setKeepOnScreenCondition { viewModel.state.value.completed }
     }
     setContent {
-      var dynamicColor by remember { mutableStateOf(false) }
+      val state = viewModel.state.collectAsState().value
       var fontFamily by remember { mutableStateOf<FontFamily>(FontFamily.Default) }
 
       HymnTheme(
-        dynamicColor = dynamicColor,
+        dynamicColor = state.dynamicColorEnabled,
         fontFamily = fontFamily
       ) {
         Surface(
@@ -47,7 +48,7 @@ class MainActivity : ComponentActivity() {
         ) {
           AppScreen(
             onThemeConfigs = { config ->
-              config.dynamicColor?.let { dynamicColor = it }
+              config.dynamicColor?.let { viewModel.onEvent(MainActivityUiEvent.DynamicColor(it)) }
               config.fontFamily?.let { fontFamily = it }
             }
           )

--- a/app/src/main/java/net/techandgraphics/hymn/ui/activity/MainActivityState.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/activity/MainActivityState.kt
@@ -2,4 +2,5 @@ package net.techandgraphics.hymn.ui.activity
 
 data class MainActivityState(
   val completed: Boolean = true,
+  val dynamicColorEnabled: Boolean = false
 )

--- a/app/src/main/java/net/techandgraphics/hymn/ui/activity/MainActivityUiEvent.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/activity/MainActivityUiEvent.kt
@@ -1,0 +1,5 @@
+package net.techandgraphics.hymn.ui.activity
+
+sealed interface MainActivityUiEvent {
+  data class DynamicColor(val isEnabled: Boolean) : MainActivityUiEvent
+}

--- a/app/src/main/java/net/techandgraphics/hymn/ui/activity/MainActivityViewModel.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/activity/MainActivityViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import net.techandgraphics.hymn.data.parser.LyricParser
 import net.techandgraphics.hymn.data.parser.OtherParser
@@ -15,7 +16,7 @@ import javax.inject.Inject
 class MainActivityViewModel @Inject constructor(
   private val lyricParser: LyricParser,
   private val otherParser: OtherParser,
-  prefs: DataStorePrefs
+  private val prefs: DataStorePrefs
 ) : ViewModel() {
 
   private val _state = MutableStateFlow(MainActivityState())
@@ -27,6 +28,8 @@ class MainActivityViewModel @Inject constructor(
 
   private fun DataStorePrefs.onInitialize() {
     viewModelScope.launch {
+      val dynamicColorEnabled = get<Boolean>(dynamicColorKey, true) ?: true
+      _state.update { it.copy(dynamicColorEnabled = dynamicColorEnabled) }
       if (get(jsonBuildKey) == DataStorePrefs.JSON_BUILD_KEY) {
         _state.value = _state.value.copy(completed = false)
         return@launch
@@ -36,6 +39,15 @@ class MainActivityViewModel @Inject constructor(
           put(jsonBuildKey, DataStorePrefs.JSON_BUILD_KEY)
           onInitialize()
         }
+      }
+    }
+  }
+
+  fun onEvent(event: MainActivityUiEvent) {
+    when (event) {
+      is MainActivityUiEvent.DynamicColor -> viewModelScope.launch {
+        prefs.get(prefs.dynamicColorKey, event.isEnabled)
+        _state.update { it.copy(dynamicColorEnabled = event.isEnabled) }
       }
     }
   }

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/app/AppScreen.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/app/AppScreen.kt
@@ -20,6 +20,7 @@ import net.techandgraphics.hymn.ui.screen.preview.PreviewScreen
 import net.techandgraphics.hymn.ui.screen.preview.PreviewUiEvent
 import net.techandgraphics.hymn.ui.screen.preview.PreviewViewModel
 import net.techandgraphics.hymn.ui.screen.settings.SettingsScreen
+import net.techandgraphics.hymn.ui.screen.settings.SettingsUiEvent
 import net.techandgraphics.hymn.ui.screen.settings.SettingsViewModel
 import net.techandgraphics.hymn.ui.screen.theCategory.TheCategoryScreen
 import net.techandgraphics.hymn.ui.screen.theCategory.TheCategoryViewModel
@@ -80,7 +81,11 @@ fun AppScreen(
         val state = state.collectAsState().value
         SettingsScreen(
           state = state,
-          onEvent = ::onEvent,
+          onEvent = {
+            if (it is SettingsUiEvent.DynamicColor)
+              onThemeConfigs.invoke(ThemeConfigs(dynamicColor = it.isEnabled))
+            onEvent(it)
+          },
           onThemeConfigs = onThemeConfigs,
           channelFlow
         )

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/settings/SettingsScreen.kt
@@ -69,7 +69,6 @@ fun SettingsScreen(
   var apostleCreedShow by remember { mutableStateOf(false) }
   var lordsPrayerShow by remember { mutableStateOf(false) }
 
-  var dynamicColor by remember { mutableStateOf(false) }
   var fontFamily by remember { mutableStateOf(false) }
   var isImporting by remember { mutableStateOf(false) }
   val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
@@ -167,13 +166,10 @@ fun SettingsScreen(
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         SettingsSwitchComp(
           drawableRes = R.drawable.ic_color,
-          title = "Wallpaper Colors",
+          title = "Theme Color",
           description = "Automatically change the color style based on your background wallpaper colors.",
-          isChecked = dynamicColor,
-          onCheckedChange = {
-            dynamicColor = it
-            onThemeConfigs.invoke(ThemeConfigs(dynamicColor = dynamicColor))
-          }
+          isChecked = state.dynamicColor,
+          onCheckedChange = { onEvent(SettingsUiEvent.DynamicColor(it)) }
         )
         HorizontalDivider()
       }

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/settings/SettingsUiEvent.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/settings/SettingsUiEvent.kt
@@ -6,6 +6,7 @@ import net.techandgraphics.hymn.domain.model.Lyric
 sealed class SettingsUiEvent {
   class RemoveFav(val data: Lyric) : SettingsUiEvent()
   class Import(val uri: Uri) : SettingsUiEvent()
+  data class DynamicColor(val isEnabled: Boolean) : SettingsUiEvent()
   data object Export : SettingsUiEvent()
   data object OpenFeedback : SettingsUiEvent()
   data object OpenRating : SettingsUiEvent()

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/settings/SettingsUiState.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/settings/SettingsUiState.kt
@@ -12,6 +12,7 @@ data class SettingsUiState(
   val complementary: List<Other> = emptyList(),
   val fontSize: Int = 2,
   val lang: Lang = Lang.EN,
+  val dynamicColor: Boolean = true,
 
   val timeSpentExport: List<TimeSpentExport> = emptyList(),
   val timeStampExport: List<TimestampExport> = emptyList(),

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/settings/SettingsViewModel.kt
@@ -60,6 +60,9 @@ class SettingsViewModel @Inject constructor(
     analytics.tagScreen(Tag.MISC_SCREEN)
     viewModelScope.launch {
       onQuery()
+      _state.update {
+        it.copy(dynamicColor = prefs.get<Boolean>(prefs.dynamicColorKey, true) ?: true)
+      }
       lyricRepo.favorites().onEach { favorites ->
         _state.value = _state.value.copy(
           favorites = favorites,
@@ -236,6 +239,14 @@ class SettingsViewModel @Inject constructor(
 
       is SettingsUiEvent.Import -> onImport(event.uri)
       SettingsUiEvent.Export -> onExport()
+      is SettingsUiEvent.DynamicColor -> onDynamicColor(event.isEnabled)
+    }
+  }
+
+  private fun onDynamicColor(isEnabled: Boolean) = viewModelScope.launch {
+    prefs.put(prefs.dynamicColorKey, isEnabled)
+    _state.update {
+      it.copy(dynamicColor = prefs.get<Boolean>(prefs.dynamicColorKey, true) ?: true)
     }
   }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="translation_key">translation_key</string>
     <string name="uniquely_crafted_key">uniquely_crafted_key</string>
     <string name="uniquely_crafted_mills_key">uniquely_crafted_mills_key</string>
+    <string name="dynamic_color">dynamic_color_enabled</string>
     <string name="shared_prefs">shared_prefs</string>
     <string name="ready_key">ready_key</string>
 


### PR DESCRIPTION

Fixes #178

### Description:
Currently, the application uses dynamic color theming to adapt the UI to the system's Material You palette. However, there is no user-facing option to enable or disable this feature, which limits customization for users who prefer a static theme.

This issue aims to implement a toggle functionality that allows users to switch between dynamic color theming and predefined static themes (e.g., light and dark modes). The feature should be integrated into the app's settings menu and include the following:

1. **Dynamic Color Detection**: Check if the device supports dynamic colors (introduced in Android 12). If unsupported, disable the toggle with appropriate messaging.
2. **Toggle Integration**: Add a switch in the settings menu to enable or disable dynamic color.
    - When disabled, the app should fall back to a predefined static theme.
    - When enabled, dynamic colors should apply across the app immediately.
3. **Persistence**: Save the user's preference using `DataStore` or a similar mechanism, ensuring the setting persists across app restarts.
4. **Theming Update**: Ensure the toggle dynamically updates the UI without requiring a restart. This includes proper handling of UI components that rely on dynamic colors.
5. **Testing**: Validate the implementation across different Android versions, focusing on devices with and without dynamic color support.