### PR TITLE
Back Navigation Issue: Keyboard Dismissal and Search Clearing Not Handled Properly

### DIFF
--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/main/MainScreen.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/main/MainScreen.kt
@@ -4,11 +4,14 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -45,7 +48,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import net.techandgraphics.hymn.Faker
@@ -58,7 +60,7 @@ import net.techandgraphics.hymn.ui.screen.main.components.LyricScreenItem
 import net.techandgraphics.hymn.ui.screen.main.components.UniquelyCraftedScreen
 import net.techandgraphics.hymn.ui.theme.HymnTheme
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun MainScreen(
   state: MainUiState,
@@ -70,6 +72,7 @@ fun MainScreen(
   val versionEntries = context.resources.getStringArray(R.array.translation_entries)
   val colorScheme = MaterialTheme.colorScheme
   var showSheet by remember { mutableStateOf(false) }
+  val isImeVisible = WindowInsets.isImeVisible
 
   val viewModel = hiltViewModel<CategoryViewModel>()
   val categoryViewModelState = viewModel.state.collectAsState().value
@@ -80,7 +83,9 @@ fun MainScreen(
     if (state.onLangInvoke) context.onTranslationChange(state.lang)
   }
 
-  BackHandler(enabled = state.searchQuery.trim().isNotEmpty()) {
+  LaunchedEffect(state.searchQuery) { if (state.searchQuery.trim().isNotEmpty()) isFocused = true }
+
+  BackHandler(enabled = state.searchQuery.trim().isNotEmpty() && !isImeVisible) {
     onEvent(MainUiEvent.LyricUiEvent.ClearLyricUiQuery)
   }
 
@@ -274,7 +279,7 @@ fun MainScreen(
   }
 }
 
-@Preview(showBackground = true)
+// @Preview(showBackground = true)
 @Composable
 fun MainScreenPreview() {
   HymnTheme {

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/main/SearchBox.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/main/SearchBox.kt
@@ -51,7 +51,6 @@ fun SearchBox(
 ) {
 
   var keyboardText by remember { mutableStateOf(false) }
-  var isFocused by remember { mutableStateOf(false) }
   val focusRequester = remember { FocusRequester() }
 
   Row(verticalAlignment = Alignment.CenterVertically) {
@@ -59,10 +58,7 @@ fun SearchBox(
       modifier = Modifier
         .weight(1f)
         .focusRequester(focusRequester)
-        .onFocusChanged { focusState ->
-          isFocused = focusState.isFocused
-          onFocusRequester(isFocused)
-        }
+        .onFocusChanged { onFocusRequester(it.isFocused) }
         .padding(horizontal = 8.dp),
       shape = RoundedCornerShape(50),
       colors = CardDefaults.elevatedCardColors(),


### PR DESCRIPTION
Fixes #182


### **Description:**
When performing a hymn search in the app, the back button behavior is not functioning as expected. Currently, pressing the back button while the soft keyboard is visible results in the app closing immediately instead of following a structured back navigation sequence.

### **Expected Behavior:**
1. **First Back Press** → The soft keyboard should be dismissed.
2. **Second Back Press** → The search bar should be cleared.
3. **Third Back Press** → The app should close.

### **Current Behavior:**
- Pressing the back button while the keyboard is open closes the app immediately instead of dismissing the keyboard.
- There is no intermediate step to clear the search bar before exiting the app.

### **Steps to Reproduce:**
1. Open the hymn search screen.
2. Tap on the search bar to bring up the soft keyboard.
3. Enter a search query.
4. Press the back button.
    - **Expected:** The keyboard should dismiss.
    - **Actual:** The app closes.
5. If the keyboard is already dismissed, pressing back should clear the search bar instead of closing the app.
6. Only after clearing the search bar, a final back press should close the app.

### **Possible Solution:**
- Implement a **custom back navigation handler** using `BackHandler` in Jetpack Compose.
- Check `WindowInsets.ime.isVisible` to first dismiss the keyboard.
- Maintain a state to track if the search bar is active and clear it on the second back press.
- Ensure the final back press closes the app only when all other states are cleared.  
