### PR TITLE
Bug fix: LyricDao Empty State Suggested Query * Remove timestamp check.

### DIFF
--- a/app/src/main/java/net/techandgraphics/hymn/data/local/dao/LyricDao.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/data/local/dao/LyricDao.kt
@@ -48,7 +48,7 @@ interface LyricDao {
   @Query("SELECT * FROM lyric WHERE favorite = 1 AND lang=:lang GROUP BY number HAVING MIN(number) ORDER BY CAST(number AS INT) ASC")
   fun favorites(lang: String): Flow<List<LyricEntity>>
 
-  @Query("SELECT * FROM lyric WHERE timestamp > 1 AND lang=:lang GROUP BY number HAVING MIN(number) ORDER BY RANDOM(), CAST(number AS INT) ASC LIMIT 4")
+  @Query("SELECT * FROM lyric WHERE lang=:lang GROUP BY number HAVING MIN(number) ORDER BY RANDOM(), CAST(number AS INT) ASC LIMIT 4")
   suspend fun emptyStateSuggested(lang: String): List<LyricEntity>
 
   @Query("SELECT * FROM lyric WHERE timestamp > 0 OR favorite = 1")


### PR DESCRIPTION
Fixed #195

#### **Description**
This PR removes the **timestamp check** from the LyricDao query, which previously restricted results to entries where the timestamp was greater than `0`. This issue caused an **empty state** for first-time users, as the timestamp had not yet been updated for any data.

#### **Changes Implemented**
- **Removed** the timestamp condition from the LyricDao query.
- Ensured that all lyrics are fetched, even if the timestamp is unset (`0`).

#### **Technical Details**
- The previous query filtered out entries where `timestamp > 1`, preventing data from being displayed for users who had not yet launched the app.
- By removing the timestamp condition, all lyrics are now accessible regardless of their timestamp state.

#### **Testing & Validation**
- **Tested on first-time app installs** to ensure lyrics are displayed immediately.
- **Verified existing data retrieval** is unaffected by the removal of the timestamp filter.
- **Checked for regressions** in query performance and result accuracy.


#### **Checklist**
- [x] Code follows project conventions and best practices
- [x] Verified query returns correct results without timestamp filtering
- [x] No new warnings or errors introduced
- [x] Documentation/comments updated where necessary  