### PR TITLE
DataStore and Flow Enhancements: Filter Nulls and Retrieve as Flow

### DIFF
--- a/app/src/main/java/net/techandgraphics/hymn/data/prefs/DataStorePrefs.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/data/prefs/DataStorePrefs.kt
@@ -11,7 +11,9 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import net.techandgraphics.hymn.R
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -55,6 +57,19 @@ class DataStorePrefs @Inject constructor(
   suspend inline fun <reified T> get(key: String, value: T): T? {
     context.dataStore.data.first().let {
       return when (value) {
+        is Int -> it[intPreferencesKey(key)] as T?
+        is String -> it[stringPreferencesKey(key)] as T?
+        is Boolean -> it[booleanPreferencesKey(key)] as T?
+        is Long -> it[longPreferencesKey(key)] as T?
+        is Float -> it[floatPreferencesKey(key)] as T?
+        else -> it[stringPreferencesKey(key)] as T?
+      }
+    }
+  }
+
+  inline fun <reified T> getAsFlow(key: String, value: T): Flow<T?> {
+    return context.dataStore.data.map {
+      when (value) {
         is Int -> it[intPreferencesKey(key)] as T?
         is String -> it[stringPreferencesKey(key)] as T?
         is Boolean -> it[booleanPreferencesKey(key)] as T?

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/main/MainViewModel.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/main/MainViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -51,14 +52,18 @@ class MainViewModel @Inject constructor(
 
   fun get() = viewModelScope.launch {
     analytics.tagScreen(Tag.MAIN_SCREEN)
-    _state.update { it.copy(lang = prefs.get(prefs.translationKey, Lang.EN.lowercase())) }
-    _state.update { it.copy(diveInto = lyricRepo.diveInto()) }
-    _state.update { it.copy(uniquelyCrafted = lyricRepo.uniquelyCrafted()) }
-    queryLyrics()
-    queryCategories()
-    querySearch()
-    queryFavorites()
-    emptyStateSuggestedLyrics()
+    prefs.getAsFlow<String>(prefs.jsonBuildKey, "")
+      .filterNotNull()
+      .onEach {
+        _state.update { it.copy(lang = prefs.get(prefs.translationKey, Lang.EN.lowercase())) }
+        _state.update { it.copy(diveInto = lyricRepo.diveInto()) }
+        _state.update { it.copy(uniquelyCrafted = lyricRepo.uniquelyCrafted()) }
+        queryLyrics()
+        queryCategories()
+        querySearch()
+        queryFavorites()
+        emptyStateSuggestedLyrics()
+      }.launchIn(viewModelScope)
   }
 
   private fun emptyStateSuggestedLyrics() = viewModelScope.launch {


### PR DESCRIPTION
Fixed #197

#### **Summary**
This PR introduces a **getAsFlow** function to **DataStorePrefs** for listening to changes in `JSON_BUILD_KEY` on the first app launch. It ensures that data is parsed and loaded before the app is ready to display it. In **MainViewModel**, the `get` function has been modified to use `getAsFlow` with `filterNotNull`, which improves the reliability of data retrieval and ensures the app displays data only after it has been loaded.

#### **Changes Implemented**
- **DataStorePrefs**:
    - Added a new `getAsFlow` function that listens for changes to `JSON_BUILD_KEY`, ensuring we can track when data has been parsed and loaded.

- **MainViewModel**:
    - Refactored the `get` function to use `prefs.getAsFlow()` and combined it with `filterNotNull()` to ensure non-null values are emitted only after the data has been successfully loaded.

#### **Technical Details**
- **getAsFlow** allows us to reactively listen to changes in `JSON_BUILD_KEY` and ensure data has been parsed before proceeding with UI display.
- **filterNotNull** ensures we only work with non-null data, preventing issues caused by an empty or invalid state.

#### **Testing & Validation**
- **Tested on first-time app launches** to confirm that data is only displayed once it has been successfully loaded.
- Verified that changes to `JSON_BUILD_KEY` are captured, and the app displays data only after parsing is complete.
- Ensured that the app behaves correctly when no data is present initially.

#### **Screenshots (if applicable)**
[Attach any relevant screenshots showing behavior before and after the change.]

#### **Checklist**
- [x] Code follows project conventions and best practices
- [x] Tested data loading on first-time app launch
- [x] No new warnings or errors introduced
- [x] Documentation/comments updated where necessary  
