### PR TITLE
Propagate Scaffold Padding to AppScreen and NavHost

### DIFF
--- a/app/src/main/java/net/techandgraphics/hymn/ui/activity/MainActivity.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/activity/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
@@ -44,12 +45,15 @@ class MainActivity : ComponentActivity() {
           modifier = Modifier.fillMaxSize(),
           color = MaterialTheme.colorScheme.background
         ) {
-          AppScreen(
-            onThemeConfigs = { config ->
-              config.dynamicColor?.let { viewModel.onEvent(DynamicColor(it)) }
-              viewModel.onEvent(FontStyle(config.fontFamily))
-            }
-          )
+          Scaffold {
+            AppScreen(
+              paddingValues = it,
+              onThemeConfigs = { config ->
+                config.dynamicColor?.let { viewModel.onEvent(DynamicColor(it)) }
+                viewModel.onEvent(FontStyle(config.fontFamily))
+              }
+            )
+          }
         }
       }
     }

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/app/AppScreen.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/app/AppScreen.kt
@@ -1,8 +1,11 @@
 package net.techandgraphics.hymn.ui.screen.app
 
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
@@ -28,10 +31,12 @@ import net.techandgraphics.hymn.ui.theme.ThemeConfigs
 
 @Composable
 fun AppScreen(
+  paddingValues: PaddingValues,
   onThemeConfigs: (ThemeConfigs) -> Unit,
   navController: NavHostController = rememberNavController(),
 ) {
   NavHost(
+    modifier = Modifier.padding(paddingValues),
     navController = navController,
     startDestination = Route.Home,
   ) {


### PR DESCRIPTION
Fixed #203


### **Description:**  
This PR refactors `AppScreen` to properly handle padding values provided by `Scaffold`, ensuring UI elements respect system insets.

### **Changes Made:**
- Passed `paddingValues` from `Scaffold` to `AppScreen`.
- Applied padding modifier to `NavHost` to maintain consistent spacing.
- Updated `MainActivity.kt` to wrap `AppScreen` inside `Scaffold` for centralized padding management.

### **Impact:**
- Prevents UI elements from overlapping system bars.
- Improves layout consistency across different device configurations.
- Enhances maintainability by centralizing padding management within `Scaffold`.

