### PR TITLE
feat: analytics queries and time_spent.createdAt migration

### DIFF
--- a/app/src/main/java/net/techandgraphics/hymn/data/local/Database.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/data/local/Database.kt
@@ -16,7 +16,7 @@ import net.techandgraphics.hymn.data.local.entities.TimestampEntity
 
 @Database(
   entities = [LyricEntity::class, SearchEntity::class, OtherEntity::class, TimestampEntity::class, TimeSpentEntity::class],
-  version = 5,
+  version = 6,
   exportSchema = false
 )
 abstract class Database : RoomDatabase() {

--- a/app/src/main/java/net/techandgraphics/hymn/data/local/Migration.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/data/local/Migration.kt
@@ -102,4 +102,12 @@ object Migration {
       db.execSQL("CREATE TABLE time_spent (lang TEXT NOT NULL,timeSpent INTEGER NOT NULL, number INTEGER NOT NULL, id INTEGER NOT NULL, PRIMARY KEY(id))")
     }
   }
+
+  val MIGRATION_5_6 = object : Migration(5, 6) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+      db.execSQL(
+        "ALTER TABLE time_spent ADD COLUMN createdAt INTEGER NOT NULL DEFAULT 0"
+      )
+    }
+  }
 }

--- a/app/src/main/java/net/techandgraphics/hymn/data/local/analytics/HymnStatRow.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/data/local/analytics/HymnStatRow.kt
@@ -1,0 +1,22 @@
+package net.techandgraphics.hymn.data.local.analytics
+
+/**
+ * Lightweight Room projection for ranked hymn analytics.
+ */
+data class HymnStatRow(
+  val number: Int,
+  val lang: String,
+  val metric: Long,
+  val title: String,
+  val categoryName: String,
+)
+
+data class CategoryStatRow(
+  val categoryName: String,
+  val visitCount: Long,
+)
+
+data class LangSplitRow(
+  val lang: String,
+  val visitCount: Long,
+)

--- a/app/src/main/java/net/techandgraphics/hymn/data/local/dao/LyricDao.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/data/local/dao/LyricDao.kt
@@ -32,6 +32,26 @@ interface LyricDao {
   @Query("SELECT * FROM lyric  WHERE  lang=:lang GROUP BY number ORDER BY timestamp DESC LIMIT 5")
   fun diveInto(lang: String): Flow<List<LyricEntity>>
 
+  @Query(
+    """
+    SELECT * FROM lyric WHERE lang=:lang AND timestamp > 0
+    GROUP BY number ORDER BY timestamp DESC LIMIT :limit
+    """
+  )
+  fun recentHistory(lang: String, limit: Int): Flow<List<LyricEntity>>
+
+  @Query(
+    """
+    SELECT * FROM lyric WHERE
+      (content LIKE'%' || :query || '%'  OR
+      title LIKE'%' || :query || '%'  OR
+      number LIKE'%' || :query || '%'  OR
+      categoryName  LIKE'%' || :query || '%' )
+      AND lang=:lang GROUP BY number HAVING MIN(number) ORDER BY title COLLATE NOCASE ASC
+    """
+  )
+  fun queryByTitle(query: String = "", lang: String): Flow<List<LyricEntity>>
+
   @Query("SELECT * FROM lyric WHERE lyricId=:lyricId")
   fun queryById(lyricId: Int): Flow<List<LyricEntity>>
 

--- a/app/src/main/java/net/techandgraphics/hymn/data/local/dao/TimeSpentDao.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/data/local/dao/TimeSpentDao.kt
@@ -3,14 +3,43 @@ package net.techandgraphics.hymn.data.local.dao
 import androidx.room.Dao
 import androidx.room.Query
 import net.techandgraphics.hymn.data.local.BaseDao
+import net.techandgraphics.hymn.data.local.analytics.HymnStatRow
 import net.techandgraphics.hymn.data.local.entities.TimeSpentEntity
 
 @Dao
 interface TimeSpentDao : BaseDao<TimeSpentEntity> {
 
-  @Query("SELECT SUM(timeSpent) as timeSpent, number, id, lang from time_spent group by number")
+  @Query("SELECT SUM(timeSpent) as timeSpent, number, id, lang, MAX(createdAt) as createdAt from time_spent group by number")
   suspend fun toExport(): List<TimeSpentEntity>
 
   @Query("SELECT COUNT(*) from time_spent WHERE number=:number AND  lang=:lang AND timeSpent=:timeSpent")
   suspend fun getCount(number: Int, lang: String, timeSpent: Long): Int
+
+  @Query(
+    """
+    SELECT t.number AS number, t.lang AS lang, SUM(t.timeSpent) AS metric,
+      COALESCE((SELECT l.title FROM lyric l WHERE l.number = t.number AND l.lang = t.lang LIMIT 1), '') AS title,
+      COALESCE((SELECT l.categoryName FROM lyric l WHERE l.number = t.number AND l.lang = t.lang LIMIT 1), '') AS categoryName
+    FROM time_spent t
+    WHERE t.lang = :lang
+      AND (:fromMs = 0 OR t.createdAt >= :fromMs)
+      AND (:toMs = 0 OR t.createdAt < :toMs)
+      AND (:fromMs = 0 OR t.createdAt > 0)
+    GROUP BY t.number, t.lang
+    ORDER BY metric DESC
+    LIMIT :limit
+    """
+  )
+  suspend fun topByTime(lang: String, fromMs: Long, toMs: Long, limit: Int): List<HymnStatRow>
+
+  @Query(
+    """
+    SELECT COALESCE(SUM(timeSpent), 0) FROM time_spent
+    WHERE lang = :lang
+      AND (:fromMs = 0 OR createdAt >= :fromMs)
+      AND (:toMs = 0 OR createdAt < :toMs)
+      AND (:fromMs = 0 OR createdAt > 0)
+    """
+  )
+  suspend fun totalTimeMs(lang: String, fromMs: Long, toMs: Long): Long
 }

--- a/app/src/main/java/net/techandgraphics/hymn/data/local/dao/TimestampDao.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/data/local/dao/TimestampDao.kt
@@ -3,6 +3,9 @@ package net.techandgraphics.hymn.data.local.dao
 import androidx.room.Dao
 import androidx.room.Query
 import net.techandgraphics.hymn.data.local.BaseDao
+import net.techandgraphics.hymn.data.local.analytics.CategoryStatRow
+import net.techandgraphics.hymn.data.local.analytics.HymnStatRow
+import net.techandgraphics.hymn.data.local.analytics.LangSplitRow
 import net.techandgraphics.hymn.data.local.entities.TimestampEntity
 
 @Dao
@@ -13,4 +16,76 @@ interface TimestampDao : BaseDao<TimestampEntity> {
 
   @Query("SELECT COUNT(*) FROM timestamp WHERE number=:number AND lang=:lang AND timestamp=:timestamp")
   suspend fun ifExist(lang: String, number: Int, timestamp: Long): Int
+
+  @Query(
+    """
+    SELECT t.number AS number, t.lang AS lang, COUNT(*) AS metric,
+      COALESCE((SELECT l.title FROM lyric l WHERE l.number = t.number AND l.lang = t.lang LIMIT 1), '') AS title,
+      COALESCE((SELECT l.categoryName FROM lyric l WHERE l.number = t.number AND l.lang = t.lang LIMIT 1), '') AS categoryName
+    FROM timestamp t
+    WHERE t.lang = :lang AND (:fromMs = 0 OR t.timestamp >= :fromMs) AND (:toMs = 0 OR t.timestamp < :toMs)
+    GROUP BY t.number, t.lang
+    ORDER BY metric DESC
+    LIMIT :limit
+    """
+  )
+  suspend fun mostVisited(lang: String, fromMs: Long, toMs: Long, limit: Int): List<HymnStatRow>
+
+  @Query(
+    """
+    SELECT COUNT(*) FROM timestamp
+    WHERE lang = :lang AND (:fromMs = 0 OR timestamp >= :fromMs) AND (:toMs = 0 OR timestamp < :toMs)
+    """
+  )
+  suspend fun totalVisits(lang: String, fromMs: Long, toMs: Long): Long
+
+  @Query(
+    """
+    SELECT COUNT(DISTINCT number) FROM timestamp
+    WHERE lang = :lang AND (:fromMs = 0 OR timestamp >= :fromMs) AND (:toMs = 0 OR timestamp < :toMs)
+    """
+  )
+  suspend fun uniqueHymns(lang: String, fromMs: Long, toMs: Long): Long
+
+  @Query(
+    """
+    SELECT DISTINCT timestamp FROM timestamp
+    WHERE lang = :lang AND (:fromMs = 0 OR timestamp >= :fromMs) AND (:toMs = 0 OR timestamp < :toMs)
+    ORDER BY timestamp DESC
+    """
+  )
+  suspend fun visitTimestamps(lang: String, fromMs: Long, toMs: Long): List<Long>
+
+  @Query(
+    """
+    SELECT COALESCE(l.categoryName, 'Unknown') AS categoryName, COUNT(*) AS visitCount
+    FROM timestamp t
+    LEFT JOIN lyric l ON l.number = t.number AND l.lang = t.lang
+    WHERE t.lang = :lang AND (:fromMs = 0 OR t.timestamp >= :fromMs) AND (:toMs = 0 OR t.timestamp < :toMs)
+    GROUP BY categoryName
+    ORDER BY visitCount DESC
+    LIMIT :limit
+    """
+  )
+  suspend fun topCategories(lang: String, fromMs: Long, toMs: Long, limit: Int): List<CategoryStatRow>
+
+  @Query(
+    """
+    SELECT lang AS lang, COUNT(*) AS visitCount FROM timestamp
+    WHERE (:fromMs = 0 OR timestamp >= :fromMs) AND (:toMs = 0 OR timestamp < :toMs)
+    GROUP BY lang
+    """
+  )
+  suspend fun languageSplit(fromMs: Long, toMs: Long): List<LangSplitRow>
+
+  @Query(
+    """
+    SELECT MAX(timestamp) AS timestamp, number, lang, id FROM timestamp
+    WHERE lang = :lang
+    GROUP BY number, lang
+    ORDER BY timestamp DESC
+    LIMIT :limit
+    """
+  )
+  suspend fun recentVisits(lang: String, limit: Int): List<TimestampEntity>
 }

--- a/app/src/main/java/net/techandgraphics/hymn/data/local/entities/TimeSpentEntity.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/data/local/entities/TimeSpentEntity.kt
@@ -8,6 +8,7 @@ import net.techandgraphics.hymn.data.local.Translation
 data class TimeSpentEntity(
   val number: Int,
   val lang: String = Translation.EN.lowercase(),
-  val timeSpent: Long = System.currentTimeMillis(),
+  val timeSpent: Long = 0,
+  val createdAt: Long = System.currentTimeMillis(),
   @PrimaryKey(autoGenerate = true) val id: Int = 0,
 )

--- a/app/src/main/java/net/techandgraphics/hymn/data/repository/InsightsRepositoryImpl.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/data/repository/InsightsRepositoryImpl.kt
@@ -1,0 +1,117 @@
+package net.techandgraphics.hymn.data.repository
+
+import net.techandgraphics.hymn.data.local.Database
+import net.techandgraphics.hymn.data.local.Translation
+import net.techandgraphics.hymn.data.local.analytics.HymnStatRow
+import net.techandgraphics.hymn.data.prefs.DataStorePrefs
+import net.techandgraphics.hymn.domain.model.CategoryAffinity
+import net.techandgraphics.hymn.domain.model.HymnStat
+import net.techandgraphics.hymn.domain.model.InsightsSummary
+import net.techandgraphics.hymn.domain.model.YearInHymnsReport
+import net.techandgraphics.hymn.domain.repository.InsightsRepository
+import java.util.Calendar
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+class InsightsRepositoryImpl @Inject constructor(
+  database: Database,
+  private val prefs: DataStorePrefs,
+) : InsightsRepository {
+
+  private val timestampDao = database.timestampDao
+  private val timeSpentDao = database.timeSpentDao
+
+  private suspend fun lang() =
+    prefs.get(prefs.translationKey, Translation.EN.lowercase())
+
+  override suspend fun summary(fromMs: Long, toMs: Long): InsightsSummary {
+    val language = lang()
+    val timestamps = timestampDao.visitTimestamps(language, fromMs, toMs)
+    val dayKeys = timestamps.map { dayKey(it) }.toSet()
+    return InsightsSummary(
+      totalVisits = timestampDao.totalVisits(language, fromMs, toMs),
+      uniqueHymns = timestampDao.uniqueHymns(language, fromMs, toMs),
+      totalTimeMs = timeSpentDao.totalTimeMs(language, fromMs, toMs),
+      activeDays = dayKeys.size,
+      currentStreak = currentStreak(dayKeys),
+    )
+  }
+
+  override suspend fun mostVisited(limit: Int, fromMs: Long, toMs: Long): List<HymnStat> {
+    return timestampDao.mostVisited(lang(), fromMs, toMs, limit).map { it.toVisitStat() }
+  }
+
+  override suspend fun topByTime(limit: Int, fromMs: Long, toMs: Long): List<HymnStat> {
+    return timeSpentDao.topByTime(lang(), fromMs, toMs, limit).map { it.toTimeStat() }
+  }
+
+  override suspend fun topCategories(
+    limit: Int,
+    fromMs: Long,
+    toMs: Long,
+  ): List<CategoryAffinity> {
+    return timestampDao.topCategories(lang(), fromMs, toMs, limit).map {
+      CategoryAffinity(it.categoryName, it.visitCount)
+    }
+  }
+
+  override suspend fun languageSplit(fromMs: Long, toMs: Long): Map<String, Long> {
+    return timestampDao.languageSplit(fromMs, toMs).associate { it.lang to it.visitCount }
+  }
+
+  override suspend fun yearReport(year: Int): YearInHymnsReport {
+    val fromMs = yearStartMs(year)
+    val toMs = yearStartMs(year + 1)
+    return YearInHymnsReport(
+      year = year,
+      summary = summary(fromMs, toMs),
+      topVisited = mostVisited(5, fromMs, toMs),
+      topByTime = topByTime(5, fromMs, toMs),
+      topCategories = topCategories(5, fromMs, toMs),
+      languageSplit = languageSplit(fromMs, toMs),
+    )
+  }
+
+  private fun HymnStatRow.toVisitStat() = HymnStat(
+    number = number,
+    lang = lang,
+    title = title,
+    categoryName = categoryName,
+    visitCount = metric,
+  )
+
+  private fun HymnStatRow.toTimeStat() = HymnStat(
+    number = number,
+    lang = lang,
+    title = title,
+    categoryName = categoryName,
+    totalTimeMs = metric,
+  )
+
+  private fun yearStartMs(year: Int): Long {
+    val calendar = Calendar.getInstance().apply {
+      clear()
+      set(Calendar.YEAR, year)
+      set(Calendar.MONTH, Calendar.JANUARY)
+      set(Calendar.DAY_OF_MONTH, 1)
+    }
+    return calendar.timeInMillis
+  }
+
+  private fun dayKey(millis: Long): Long = TimeUnit.MILLISECONDS.toDays(millis)
+
+  private fun currentStreak(dayKeys: Set<Long>): Int {
+    if (dayKeys.isEmpty()) return 0
+    var day = dayKey(System.currentTimeMillis())
+    if (day !in dayKeys) {
+      day -= 1
+      if (day !in dayKeys) return 0
+    }
+    var streak = 0
+    while (day in dayKeys) {
+      streak++
+      day--
+    }
+    return streak
+  }
+}

--- a/app/src/main/java/net/techandgraphics/hymn/data/repository/LyricRepositoryImpl.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/data/repository/LyricRepositoryImpl.kt
@@ -38,6 +38,18 @@ class LyricRepositoryImpl @Inject constructor(
     }
   }
 
+  override fun recentHistory(limit: Int): Flow<List<Lyric>> {
+    return runBlocking {
+      dao.recentHistory(getLang(), limit).map { data -> data.map { it.asModel() } }
+    }
+  }
+
+  override fun queryByTitle(query: String): Flow<List<Lyric>> {
+    return runBlocking {
+      dao.queryByTitle(query, getLang()).map { it.map { data -> data.asModel() } }
+    }
+  }
+
   override suspend fun toExport(): List<Int> {
     return dao.toExport()
   }

--- a/app/src/main/java/net/techandgraphics/hymn/di/AppModule.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/di/AppModule.kt
@@ -11,6 +11,7 @@ import net.techandgraphics.hymn.data.local.Database
 import net.techandgraphics.hymn.data.local.Migration
 import net.techandgraphics.hymn.data.local.Migration.MIGRATION_3_4
 import net.techandgraphics.hymn.data.local.Migration.MIGRATION_4_5
+import net.techandgraphics.hymn.data.local.Migration.MIGRATION_5_6
 import javax.inject.Singleton
 
 @Module
@@ -22,6 +23,6 @@ object AppModule {
   fun providesDatabase(
     @ApplicationContext context: Context
   ): Database = Room.databaseBuilder(context, Database::class.java, "hymn_repo")
-    .addMigrations(Migration.MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+    .addMigrations(Migration.MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
     .build()
 }

--- a/app/src/main/java/net/techandgraphics/hymn/di/RepositoryModule.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/di/RepositoryModule.kt
@@ -5,12 +5,14 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import net.techandgraphics.hymn.data.repository.CategoryRepositoryImpl
+import net.techandgraphics.hymn.data.repository.InsightsRepositoryImpl
 import net.techandgraphics.hymn.data.repository.LyricRepositoryImpl
 import net.techandgraphics.hymn.data.repository.OtherRepositoryImpl
 import net.techandgraphics.hymn.data.repository.SearchRepositoryImpl
 import net.techandgraphics.hymn.data.repository.TimeSpentRepositoryImpl
 import net.techandgraphics.hymn.data.repository.TimestampRepositoryImpl
 import net.techandgraphics.hymn.domain.repository.CategoryRepository
+import net.techandgraphics.hymn.domain.repository.InsightsRepository
 import net.techandgraphics.hymn.domain.repository.LyricRepository
 import net.techandgraphics.hymn.domain.repository.OtherRepository
 import net.techandgraphics.hymn.domain.repository.SearchRepository
@@ -38,4 +40,7 @@ abstract class RepositoryModule {
 
   @Binds
   abstract fun providesTimeSpentRepository(p0: TimeSpentRepositoryImpl): TimeSpentRepository
+
+  @Binds
+  abstract fun providesInsightsRepository(p0: InsightsRepositoryImpl): InsightsRepository
 }

--- a/app/src/main/java/net/techandgraphics/hymn/domain/model/Analytics.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/domain/model/Analytics.kt
@@ -1,0 +1,32 @@
+package net.techandgraphics.hymn.domain.model
+
+data class HymnStat(
+  val number: Int,
+  val lang: String,
+  val title: String,
+  val categoryName: String,
+  val visitCount: Long = 0,
+  val totalTimeMs: Long = 0,
+)
+
+data class CategoryAffinity(
+  val categoryName: String,
+  val visitCount: Long,
+)
+
+data class InsightsSummary(
+  val totalVisits: Long,
+  val uniqueHymns: Long,
+  val totalTimeMs: Long,
+  val activeDays: Int,
+  val currentStreak: Int,
+)
+
+data class YearInHymnsReport(
+  val year: Int,
+  val summary: InsightsSummary,
+  val topVisited: List<HymnStat>,
+  val topByTime: List<HymnStat>,
+  val topCategories: List<CategoryAffinity>,
+  val languageSplit: Map<String, Long>,
+)

--- a/app/src/main/java/net/techandgraphics/hymn/domain/repository/InsightsRepository.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/domain/repository/InsightsRepository.kt
@@ -1,0 +1,15 @@
+package net.techandgraphics.hymn.domain.repository
+
+import net.techandgraphics.hymn.domain.model.CategoryAffinity
+import net.techandgraphics.hymn.domain.model.HymnStat
+import net.techandgraphics.hymn.domain.model.InsightsSummary
+import net.techandgraphics.hymn.domain.model.YearInHymnsReport
+
+interface InsightsRepository {
+  suspend fun summary(fromMs: Long = 0L, toMs: Long = 0L): InsightsSummary
+  suspend fun mostVisited(limit: Int = 10, fromMs: Long = 0L, toMs: Long = 0L): List<HymnStat>
+  suspend fun topByTime(limit: Int = 10, fromMs: Long = 0L, toMs: Long = 0L): List<HymnStat>
+  suspend fun topCategories(limit: Int = 5, fromMs: Long = 0L, toMs: Long = 0L): List<CategoryAffinity>
+  suspend fun languageSplit(fromMs: Long = 0L, toMs: Long = 0L): Map<String, Long>
+  suspend fun yearReport(year: Int): YearInHymnsReport
+}

--- a/app/src/main/java/net/techandgraphics/hymn/domain/repository/LyricRepository.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/domain/repository/LyricRepository.kt
@@ -7,6 +7,8 @@ interface LyricRepository {
   fun query(query: String): Flow<List<Lyric>>
   fun queryByCategory(id: Int): Flow<List<Lyric>>
   fun diveInto(): Flow<List<Lyric>>
+  fun recentHistory(limit: Int = 50): Flow<List<Lyric>>
+  fun queryByTitle(query: String): Flow<List<Lyric>>
   suspend fun toExport(): List<Int>
   fun queryById(lyricId: Int): Flow<List<Lyric>>
   fun favorites(): Flow<List<Lyric>>

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/preview/PreviewViewModel.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/preview/PreviewViewModel.kt
@@ -219,7 +219,8 @@ class PreviewViewModel @Inject constructor(
     val timeSpent = TimeSpentEntity(
       number = currentLyric.number,
       timeSpent = if (timeSpentMills > maxTimeSpent) maxTimeSpent else timeSpentMills,
-      lang = currentLyric.lang
+      lang = currentLyric.lang,
+      createdAt = System.currentTimeMillis(),
     )
     runBlocking { withContext(Dispatchers.IO) { timeSpentRepo.upsert(listOf(timeSpent)) } }
   }


### PR DESCRIPTION
## Summary
Adds Room migration for `time_spent.createdAt` (DB v6) plus DAO/repository aggregations for most visited, time spent, categories, streaks, and Year in Hymns reports.

## Changes
- **data**
  - TimeSpentEntity.createdAt + MIGRATION_5_6
  - TimestampDao / TimeSpentDao analytics queries
  - InsightsRepository + LyricDao recentHistory / queryByTitle
  - PreviewViewModel writes createdAt on session end

## Test plan
- [x] ./gradlew spotlessApply
- [x] ./gradlew :app:compileDebugKotlin

Closes #254