### PR TITLE
feat: bottom navigation shell and new routes

### DIFF
--- a/app/src/main/java/net/techandgraphics/hymn/ui/Route.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/Route.kt
@@ -4,8 +4,13 @@ import kotlinx.serialization.Serializable
 
 sealed interface Route {
   @Serializable data object Home : Route
+  @Serializable data object Browse : Route
+  @Serializable data object Insights : Route
+  @Serializable data object Library : Route
+  @Serializable data object Favorites : Route
+  @Serializable data object History : Route
   @Serializable data object Settings : Route
-  @Serializable data object Category : Route
+  @Serializable data class YearInHymns(val year: Int) : Route
   @Serializable data class Preview(val id: Int) : Route
   @Serializable data class TheCategory(val id: Int) : Route
 }

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/app/AppScreen.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/app/AppScreen.kt
@@ -2,14 +2,19 @@ package net.techandgraphics.hymn.ui.screen.app
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import net.techandgraphics.hymn.ui.Route
@@ -29,6 +34,7 @@ import net.techandgraphics.hymn.ui.screen.theCategory.TheCategoryUiEvent.Favorit
 import net.techandgraphics.hymn.ui.screen.theCategory.TheCategoryUiEvent.ToPreview
 import net.techandgraphics.hymn.ui.screen.theCategory.TheCategoryViewModel
 import net.techandgraphics.hymn.ui.theme.ThemeConfigs
+import java.util.Calendar
 
 @Composable
 fun AppScreen(
@@ -36,83 +42,151 @@ fun AppScreen(
   onThemeConfigs: (ThemeConfigs) -> Unit,
   navController: NavHostController = rememberNavController(),
 ) {
-  NavHost(
+  val backStackEntry by navController.currentBackStackEntryAsState()
+  val destination = backStackEntry?.destination
+  val selectedTab = HymnBottomTabs.firstOrNull { tab ->
+    destination?.hasRoute(tab.route::class) == true
+  }?.route
+  val showBottomBar = destination != null && (
+    destination.hasRoute<Route.Home>() ||
+      destination.hasRoute<Route.Browse>() ||
+      destination.hasRoute<Route.Insights>() ||
+      destination.hasRoute<Route.Library>()
+    )
+
+  Scaffold(
     modifier = Modifier.padding(paddingValues),
-    navController = navController,
-    startDestination = Route.Home,
-  ) {
+    bottomBar = {
+      if (showBottomBar) {
+        HymnBottomBar(
+          selectedRoute = selectedTab,
+          onSelect = { route ->
+            navController.navigate(route) {
+              popUpTo(navController.graph.findStartDestination().id) {
+                saveState = true
+              }
+              launchSingleTop = true
+              restoreState = true
+            }
+          },
+        )
+      }
+    },
+  ) { innerPadding ->
+    NavHost(
+      modifier = Modifier.padding(innerPadding),
+      navController = navController,
+      startDestination = Route.Home,
+    ) {
+      composable<Route.Home> {
+        with(hiltViewModel<MainViewModel>()) {
+          val state = state.collectAsStateWithLifecycle().value
+          MainScreen(state = state, channelFlow = channelFlow) { event ->
+            when (event) {
+              is MainUiEvent.GotoPreview ->
+                navController.navigate(Route.Preview(event.lyric.number))
 
-    composable<Route.Home> {
-      with(hiltViewModel<MainViewModel>()) {
-        val state = state.collectAsStateWithLifecycle().value
-        MainScreen(state = state, channelFlow = channelFlow) { event ->
-          when (event) {
-            is MainUiEvent.GotoPreview ->
-              navController.navigate(Route.Preview(event.lyric.number))
+              is MainUiEvent.GotoCategory ->
+                navController.navigate(Route.TheCategory(event.category.lyric.categoryId))
 
-            is MainUiEvent.GotoCategory ->
-              navController.navigate(Route.TheCategory(event.category.lyric.categoryId))
+              is MainUiEvent.MenuItem.Settings -> navController.navigate(Route.Settings)
 
-            is MainUiEvent.MenuItem.Settings -> navController.navigate(Route.Settings)
-
-            else -> onEvent(event)
+              else -> onEvent(event)
+            }
           }
         }
       }
-    }
 
-    composable<Route.Settings> {
-      with(hiltViewModel<SettingsViewModel>()) {
-        val state = state.collectAsStateWithLifecycle().value
-        SettingsScreen(
-          state = state,
-          onEvent = {
-            if (it is SettingsEvent.DynamicColor)
-              onThemeConfigs.invoke(ThemeConfigs(dynamicColor = it.isEnabled))
-
-            if (it is SettingsEvent.FontStyle.Apply)
-              onThemeConfigs.invoke(ThemeConfigs(fontFamily = it.fontFamily))
-
-            onEvent(it)
-          },
-          channelFlow = channelFlow
+      composable<Route.Browse> {
+        PlaceholderScreen(
+          title = "Browse",
+          subtitle = "All hymns will appear here next",
         )
       }
-    }
 
-    composable<Route.Preview> {
-      with(hiltViewModel<PreviewViewModel>()) {
-        LaunchedEffect(Unit) { invoke(it.toRoute<Route.Preview>().id) }
-        val state = state.collectAsStateWithLifecycle().value
-        state.currentLyric
-          .takeIf { it != null }
-          ?.let {
-            PreviewScreen(state) { event ->
-              when (event) {
-                GoToTheCategory -> {
-                  onEvent(PreviewUiEvent.Analytics.GotoTheCategory)
-                  navController.navigate(Route.TheCategory(state.categoryId))
+      composable<Route.Insights> {
+        PlaceholderScreen(
+          title = "Insights",
+          subtitle = "Tap through to Year in Hymns soon",
+        )
+      }
+
+      composable<Route.Library> {
+        PlaceholderScreen(
+          title = "Library",
+          subtitle = "Favorites, history, and settings hub",
+        )
+      }
+
+      composable<Route.Favorites> {
+        PlaceholderScreen(title = "Favorites")
+      }
+
+      composable<Route.History> {
+        PlaceholderScreen(title = "History")
+      }
+
+      composable<Route.YearInHymns> {
+        val year = it.toRoute<Route.YearInHymns>().year
+        PlaceholderScreen(title = "Year in Hymns · $year")
+      }
+
+      composable<Route.Settings> {
+        with(hiltViewModel<SettingsViewModel>()) {
+          val state = state.collectAsStateWithLifecycle().value
+          SettingsScreen(
+            state = state,
+            onEvent = {
+              if (it is SettingsEvent.DynamicColor)
+                onThemeConfigs.invoke(ThemeConfigs(dynamicColor = it.isEnabled))
+
+              if (it is SettingsEvent.FontStyle.Apply)
+                onThemeConfigs.invoke(ThemeConfigs(fontFamily = it.fontFamily))
+
+              onEvent(it)
+            },
+            channelFlow = channelFlow
+          )
+        }
+      }
+
+      composable<Route.Preview> {
+        with(hiltViewModel<PreviewViewModel>()) {
+          LaunchedEffect(Unit) { invoke(it.toRoute<Route.Preview>().id) }
+          val state = state.collectAsStateWithLifecycle().value
+          state.currentLyric
+            .takeIf { lyric -> lyric != null }
+            ?.let {
+              PreviewScreen(state) { event ->
+                when (event) {
+                  GoToTheCategory -> {
+                    onEvent(PreviewUiEvent.Analytics.GotoTheCategory)
+                    navController.navigate(Route.TheCategory(state.categoryId))
+                  }
+
+                  PopBackStack -> navController.popBackStack()
+                  else -> onEvent(event)
                 }
-
-                PopBackStack -> navController.popBackStack()
-                else -> onEvent(event)
               }
             }
-          }
+        }
       }
-    }
 
-    composable<Route.TheCategory> {
-      with(hiltViewModel<TheCategoryViewModel>()) {
-        LaunchedEffect(Unit) { invoke(it.toRoute<Route.TheCategory>().id) }
-        val state = state.collectAsStateWithLifecycle().value
-        TheCategoryScreen(state = state) { event ->
-          when (event) {
-            is Favorite -> onEvent(event)
-            is ToPreview -> navController.navigate(Route.Preview(event.theHymnNumber))
+      composable<Route.TheCategory> {
+        with(hiltViewModel<TheCategoryViewModel>()) {
+          LaunchedEffect(Unit) { invoke(it.toRoute<Route.TheCategory>().id) }
+          val state = state.collectAsStateWithLifecycle().value
+          TheCategoryScreen(state = state) { event ->
+            when (event) {
+              is Favorite -> onEvent(event)
+              is ToPreview -> navController.navigate(Route.Preview(event.theHymnNumber))
+            }
           }
         }
       }
     }
   }
 }
+
+/** Helper for Insights CTA in a later PR. */
+fun currentYear(): Int = Calendar.getInstance().get(Calendar.YEAR)

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/app/HymnBottomBar.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/app/HymnBottomBar.kt
@@ -1,0 +1,45 @@
+package net.techandgraphics.hymn.ui.screen.app
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.Insights
+import androidx.compose.material.icons.outlined.LibraryMusic
+import androidx.compose.material.icons.outlined.MenuBook
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import net.techandgraphics.hymn.ui.Route
+
+data class BottomTab(
+  val route: Route,
+  val label: String,
+  val icon: ImageVector,
+)
+
+val HymnBottomTabs = listOf(
+  BottomTab(Route.Home, "Home", Icons.Outlined.Home),
+  BottomTab(Route.Browse, "Browse", Icons.Outlined.MenuBook),
+  BottomTab(Route.Insights, "Insights", Icons.Outlined.Insights),
+  BottomTab(Route.Library, "Library", Icons.Outlined.LibraryMusic),
+)
+
+@Composable
+fun HymnBottomBar(
+  selectedRoute: Route?,
+  onSelect: (Route) -> Unit,
+) {
+  NavigationBar {
+    HymnBottomTabs.forEach { tab ->
+      val selected = selectedRoute?.let { it::class == tab.route::class } == true
+      NavigationBarItem(
+        selected = selected,
+        onClick = { onSelect(tab.route) },
+        icon = { Icon(tab.icon, contentDescription = tab.label) },
+        label = { Text(tab.label) },
+      )
+    }
+  }
+}

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/app/PlaceholderScreen.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/app/PlaceholderScreen.kt
@@ -1,0 +1,40 @@
+package net.techandgraphics.hymn.ui.screen.app
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PlaceholderScreen(
+  title: String,
+  subtitle: String = "Coming in a follow-up update",
+) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .padding(24.dp),
+    verticalArrangement = Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Text(
+      text = title,
+      style = MaterialTheme.typography.headlineSmall,
+      textAlign = TextAlign.Center,
+    )
+    Text(
+      text = subtitle,
+      style = MaterialTheme.typography.bodyMedium,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      textAlign = TextAlign.Center,
+      modifier = Modifier.padding(top = 8.dp),
+    )
+  }
+}


### PR DESCRIPTION
## Summary
Adds bottom navigation for Home, Browse, Insights, and Library with placeholder screens and typed routes for Favorites, History, and Year in Hymns.

## Changes
- **ui**
  - Route.kt expanded
  - HymnBottomBar + PlaceholderScreen
  - AppScreen Scaffold with bar visibility rules

## Test plan
- [x] ./gradlew spotlessApply
- [x] ./gradlew :app:compileDebugKotlin

Closes #256