### PR TITLE
feat: Browse all hymns screen

### DIFF
--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/app/AppScreen.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/app/AppScreen.kt
@@ -18,6 +18,9 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import net.techandgraphics.hymn.ui.Route
+import net.techandgraphics.hymn.ui.screen.browse.BrowseScreen
+import net.techandgraphics.hymn.ui.screen.browse.BrowseUiEvent
+import net.techandgraphics.hymn.ui.screen.browse.BrowseViewModel
 import net.techandgraphics.hymn.ui.screen.main.MainScreen
 import net.techandgraphics.hymn.ui.screen.main.MainUiEvent
 import net.techandgraphics.hymn.ui.screen.main.MainViewModel
@@ -34,7 +37,6 @@ import net.techandgraphics.hymn.ui.screen.theCategory.TheCategoryUiEvent.Favorit
 import net.techandgraphics.hymn.ui.screen.theCategory.TheCategoryUiEvent.ToPreview
 import net.techandgraphics.hymn.ui.screen.theCategory.TheCategoryViewModel
 import net.techandgraphics.hymn.ui.theme.ThemeConfigs
-import java.util.Calendar
 
 @Composable
 fun AppScreen(
@@ -98,10 +100,20 @@ fun AppScreen(
       }
 
       composable<Route.Browse> {
-        PlaceholderScreen(
-          title = "Browse",
-          subtitle = "All hymns will appear here next",
-        )
+        with(hiltViewModel<BrowseViewModel>()) {
+          val state = state.collectAsStateWithLifecycle().value
+          BrowseScreen(state = state) { event ->
+            when (event) {
+              is BrowseUiEvent.OpenHymn ->
+                navController.navigate(Route.Preview(event.number))
+
+              is BrowseUiEvent.OpenCategory ->
+                navController.navigate(Route.TheCategory(event.categoryId))
+
+              else -> onEvent(event)
+            }
+          }
+        }
       }
 
       composable<Route.Insights> {
@@ -187,6 +199,3 @@ fun AppScreen(
     }
   }
 }
-
-/** Helper for Insights CTA in a later PR. */
-fun currentYear(): Int = Calendar.getInstance().get(Calendar.YEAR)

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/browse/BrowseScreen.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/browse/BrowseScreen.kt
@@ -1,0 +1,164 @@
+package net.techandgraphics.hymn.ui.screen.browse
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import net.techandgraphics.hymn.domain.model.Category
+import net.techandgraphics.hymn.domain.model.Lyric
+import net.techandgraphics.hymn.toNumber
+import net.techandgraphics.hymn.ui.screen.component.ImageComponent
+
+@Composable
+fun BrowseScreen(
+  state: BrowseUiState,
+  onEvent: (BrowseUiEvent) -> Unit,
+) {
+  Column(modifier = Modifier.fillMaxSize()) {
+    Text(
+      text = "Browse",
+      style = MaterialTheme.typography.headlineSmall,
+      fontWeight = FontWeight.Bold,
+      modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+    )
+    OutlinedTextField(
+      value = state.query,
+      onValueChange = { onEvent(BrowseUiEvent.Query(it)) },
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 16.dp),
+      singleLine = true,
+      placeholder = { Text("Search hymns") },
+    )
+    Row(
+      modifier = Modifier
+        .horizontalScroll(rememberScrollState())
+        .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+      BrowseSort.entries.forEach { sort ->
+        FilterChip(
+          selected = state.sort == sort,
+          onClick = { onEvent(BrowseUiEvent.Sort(sort)) },
+          label = { Text(sort.name) },
+          modifier = Modifier.padding(end = 8.dp),
+        )
+      }
+      FilterChip(
+        selected = state.favoritesOnly,
+        onClick = { onEvent(BrowseUiEvent.ToggleFavoritesOnly) },
+        label = { Text("Favorites") },
+      )
+    }
+
+    when (state.sort) {
+      BrowseSort.Categories -> LazyColumn {
+        items(state.categories, key = { it.lyric.categoryId }) { category ->
+          CategoryBrowseRow(category) {
+            onEvent(BrowseUiEvent.OpenCategory(category.lyric.categoryId))
+          }
+        }
+      }
+
+      else -> LazyColumn {
+        items(state.hymns, key = { it.number }) { hymn ->
+          HymnBrowseRow(
+            lyric = hymn,
+            onOpen = { onEvent(BrowseUiEvent.OpenHymn(hymn.number)) },
+            onFavorite = {
+              onEvent(BrowseUiEvent.Favorite(hymn.number, !hymn.favorite))
+            },
+          )
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun HymnBrowseRow(
+  lyric: Lyric,
+  onOpen: () -> Unit,
+  onFavorite: () -> Unit,
+) {
+  Column(modifier = Modifier.clickable(onClick = onOpen)) {
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier.padding(horizontal = 8.dp, vertical = 12.dp),
+    ) {
+      ImageComponent(lyric)
+      Column(
+        modifier = Modifier
+          .weight(1f)
+          .padding(horizontal = 12.dp),
+      ) {
+        Text(text = lyric.toNumber(), fontWeight = FontWeight.Bold)
+        Text(
+          text = lyric.title,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+          color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+          text = lyric.categoryName,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+          style = MaterialTheme.typography.bodySmall,
+        )
+      }
+      IconButton(onClick = onFavorite) {
+        Icon(
+          imageVector = if (lyric.favorite) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+          contentDescription = "Favorite",
+        )
+      }
+    }
+    HorizontalDivider(modifier = Modifier.padding(start = 72.dp, end = 16.dp))
+  }
+}
+
+@Composable
+private fun CategoryBrowseRow(category: Category, onOpen: () -> Unit) {
+  Column(modifier = Modifier.clickable(onClick = onOpen)) {
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier.padding(horizontal = 8.dp, vertical = 12.dp),
+    ) {
+      ImageComponent(category.lyric)
+      Column(modifier = Modifier.padding(horizontal = 12.dp)) {
+        Text(
+          text = category.lyric.categoryName,
+          fontWeight = FontWeight.Bold,
+          maxLines = 2,
+          overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+          text = category.count.substringBefore("-") + " hymns",
+          style = MaterialTheme.typography.bodySmall,
+        )
+      }
+    }
+    HorizontalDivider(modifier = Modifier.padding(start = 72.dp, end = 16.dp))
+  }
+}

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/browse/BrowseUi.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/browse/BrowseUi.kt
@@ -1,0 +1,24 @@
+package net.techandgraphics.hymn.ui.screen.browse
+
+enum class BrowseSort {
+  Number,
+  Title,
+  Categories,
+}
+
+data class BrowseUiState(
+  val query: String = "",
+  val sort: BrowseSort = BrowseSort.Number,
+  val favoritesOnly: Boolean = false,
+  val hymns: List<net.techandgraphics.hymn.domain.model.Lyric> = emptyList(),
+  val categories: List<net.techandgraphics.hymn.domain.model.Category> = emptyList(),
+)
+
+sealed interface BrowseUiEvent {
+  data class Query(val value: String) : BrowseUiEvent
+  data class Sort(val sort: BrowseSort) : BrowseUiEvent
+  data object ToggleFavoritesOnly : BrowseUiEvent
+  data class OpenHymn(val number: Int) : BrowseUiEvent
+  data class OpenCategory(val categoryId: Int) : BrowseUiEvent
+  data class Favorite(val number: Int, val favorite: Boolean) : BrowseUiEvent
+}

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/browse/BrowseViewModel.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/browse/BrowseViewModel.kt
@@ -1,0 +1,86 @@
+package net.techandgraphics.hymn.ui.screen.browse
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import net.techandgraphics.hymn.domain.repository.CategoryRepository
+import net.techandgraphics.hymn.domain.repository.LyricRepository
+import javax.inject.Inject
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class BrowseViewModel @Inject constructor(
+  private val lyricRepo: LyricRepository,
+  private val categoryRepo: CategoryRepository,
+) : ViewModel() {
+
+  private val query = MutableStateFlow("")
+  private val sort = MutableStateFlow(BrowseSort.Number)
+  private val favoritesOnly = MutableStateFlow(false)
+
+  val state = combine(query, sort, favoritesOnly) { q, s, fav ->
+    Triple(q, s, fav)
+  }.flatMapLatest { (q, s, fav) ->
+    flow {
+      when (s) {
+        BrowseSort.Categories -> {
+          emit(
+            BrowseUiState(
+              query = q,
+              sort = s,
+              favoritesOnly = fav,
+              categories = categoryRepo.query(q),
+            )
+          )
+        }
+
+        BrowseSort.Title -> {
+          lyricRepo.queryByTitle(q).collect { hymns ->
+            emit(
+              BrowseUiState(
+                query = q,
+                sort = s,
+                favoritesOnly = fav,
+                hymns = hymns.filter { !fav || it.favorite },
+              )
+            )
+          }
+        }
+
+        BrowseSort.Number -> {
+          lyricRepo.query(q).collect { hymns ->
+            emit(
+              BrowseUiState(
+                query = q,
+                sort = s,
+                favoritesOnly = fav,
+                hymns = hymns.filter { !fav || it.favorite },
+              )
+            )
+          }
+        }
+      }
+    }
+  }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), BrowseUiState())
+
+  fun onEvent(event: BrowseUiEvent) {
+    when (event) {
+      is BrowseUiEvent.Query -> query.update { event.value }
+      is BrowseUiEvent.Sort -> sort.update { event.sort }
+      BrowseUiEvent.ToggleFavoritesOnly -> favoritesOnly.update { !it }
+      is BrowseUiEvent.Favorite -> viewModelScope.launch {
+        lyricRepo.favorite(event.favorite, event.number)
+      }
+      is BrowseUiEvent.OpenHymn, is BrowseUiEvent.OpenCategory -> Unit
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Replaces the Browse placeholder with a searchable hymn browser (by number, title, or categories) including a favorites filter.

## Test plan
- [x] ./gradlew :app:compileDebugKotlin

Closes #260