### PR TITLE
feat: polish Insights and Year in Hymns to the mockup

### DIFF
--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/insights/InsightsScreen.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/insights/InsightsScreen.kt
@@ -1,25 +1,48 @@
 package net.techandgraphics.hymn.ui.screen.insights
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.DateRange
+import androidx.compose.material.icons.rounded.Favorite
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Star
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.stringResource
+import net.techandgraphics.hymn.R
 import net.techandgraphics.hymn.domain.model.HymnStat
+import net.techandgraphics.hymn.ui.components.EmptyState
+import net.techandgraphics.hymn.ui.components.HymnTopAppBar
+import net.techandgraphics.hymn.ui.components.InfoPill
+import net.techandgraphics.hymn.ui.components.NoAppBarInsets
+import net.techandgraphics.hymn.ui.components.RankedBarRow
+import net.techandgraphics.hymn.ui.components.SectionHeader
+import net.techandgraphics.hymn.ui.components.StatTile
+import net.techandgraphics.hymn.ui.theme.PillShape
+import net.techandgraphics.hymn.ui.theme.Space
 import java.util.concurrent.TimeUnit
 
+/**
+ * Reading stats. The previous version stacked bare `Text` rows; numbers are now
+ * tiles you can scan and rankings are proportional bars you can compare.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InsightsScreen(
   state: InsightsUiState,
@@ -27,97 +50,171 @@ fun InsightsScreen(
   onOpenHymn: (Int) -> Unit,
   onYearInHymns: () -> Unit,
 ) {
-  Column(
-    modifier = Modifier
-      .fillMaxSize()
-      .verticalScroll(rememberScrollState())
-      .padding(16.dp),
-  ) {
-    Text(
-      text = "Insights",
-      style = MaterialTheme.typography.headlineSmall,
-      fontWeight = FontWeight.Bold,
-    )
-    Row(modifier = Modifier.padding(vertical = 8.dp)) {
-      FilterChip(
-        selected = !state.thisYearOnly,
-        onClick = { if (state.thisYearOnly) onToggleYear() },
-        label = { Text("All time") },
-        modifier = Modifier.padding(end = 8.dp),
+  val scrollBehavior =
+    TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+
+  Scaffold(
+    contentWindowInsets = NoAppBarInsets,
+    modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+    topBar = {
+      HymnTopAppBar(
+        title = stringResource(R.string.nav_insights),
+        scrollBehavior = scrollBehavior,
       )
-      FilterChip(
-        selected = state.thisYearOnly,
-        onClick = { if (!state.thisYearOnly) onToggleYear() },
-        label = { Text("This year") },
-      )
-    }
-
-    if (state.summary.totalVisits == 0L) {
-      Text(
-        text = "Open a few hymns to unlock your insights.",
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(vertical = 24.dp),
-      )
-      return
-    }
-
-    Card(modifier = Modifier.fillMaxWidth()) {
-      Column(modifier = Modifier.padding(16.dp)) {
-        Text("${state.summary.totalVisits} opens", fontWeight = FontWeight.Bold)
-        Text("${state.summary.uniqueHymns} hymns · ${formatDuration(state.summary.totalTimeMs)}")
-        Text("${state.summary.activeDays} active days · ${state.summary.currentStreak}-day streak")
-      }
-    }
-
-    SectionTitle("Most visited")
-    state.mostVisited.forEach { StatRow(it, "${it.visitCount} opens", onOpenHymn) }
-
-    SectionTitle("Longest time with")
-    state.topByTime.forEach { StatRow(it, formatDuration(it.totalTimeMs), onOpenHymn) }
-
-    SectionTitle("Your themes")
-    state.themes.forEach { theme ->
-      Text(
-        text = "${theme.categoryName} · ${theme.visitCount}",
-        modifier = Modifier.padding(vertical = 4.dp),
-      )
-    }
-
-    Button(
-      onClick = onYearInHymns,
+    },
+  ) { padding ->
+    LazyColumn(
       modifier = Modifier
-        .fillMaxWidth()
-        .padding(top = 24.dp),
+        .fillMaxSize()
+        .padding(padding),
+      contentPadding = PaddingValues(bottom = Space.lg),
     ) {
-      Text("Your Year in Hymns")
+      item {
+        Row(
+          horizontalArrangement = Arrangement.spacedBy(Space.xs),
+          modifier = Modifier.padding(horizontal = Space.md, vertical = Space.xs),
+        ) {
+          FilterChip(
+            selected = !state.thisYearOnly,
+            onClick = { if (state.thisYearOnly) onToggleYear() },
+            label = { Text(stringResource(R.string.insights_all_time)) },
+            shape = PillShape,
+          )
+          FilterChip(
+            selected = state.thisYearOnly,
+            onClick = { if (!state.thisYearOnly) onToggleYear() },
+            label = { Text(stringResource(R.string.insights_this_year)) },
+            shape = PillShape,
+          )
+        }
+      }
+
+      if (state.summary.totalVisits == 0L) {
+        item {
+          EmptyState(
+            icon = Icons.Rounded.Star,
+            title = stringResource(R.string.insights_empty_title),
+            message = stringResource(R.string.insights_empty),
+          )
+        }
+        return@LazyColumn
+      }
+
+      item {
+        Column(modifier = Modifier.padding(horizontal = Space.md)) {
+          Row(horizontalArrangement = Arrangement.spacedBy(Space.xs)) {
+            StatTile(
+              value = state.summary.totalVisits.toString(),
+              label = stringResource(R.string.insights_opens),
+              icon = Icons.Rounded.PlayArrow,
+              modifier = Modifier.weight(1f),
+            )
+            StatTile(
+              value = state.summary.uniqueHymns.toString(),
+              label = stringResource(R.string.insights_hymns),
+              icon = Icons.Rounded.Favorite,
+              modifier = Modifier.weight(1f),
+            )
+          }
+          Row(
+            horizontalArrangement = Arrangement.spacedBy(Space.xs),
+            modifier = Modifier.padding(top = Space.xs),
+          ) {
+            StatTile(
+              value = formatDuration(state.summary.totalTimeMs),
+              label = stringResource(R.string.insights_time),
+              icon = Icons.Rounded.DateRange,
+              modifier = Modifier.weight(1f),
+            )
+            StatTile(
+              value = state.summary.currentStreak.toString(),
+              label = stringResource(R.string.insights_streak),
+              icon = Icons.Rounded.Star,
+              modifier = Modifier.weight(1f),
+            )
+          }
+        }
+      }
+
+      if (state.mostVisited.isNotEmpty()) {
+        item { SectionHeader(title = stringResource(R.string.insights_most_visited)) }
+        val max = state.mostVisited.maxOf { it.visitCount }.coerceAtLeast(1)
+        itemsIndexed(state.mostVisited, key = { _, it -> "visit-${it.number}-${it.lang}" }) { i, s ->
+          StatBar(
+            rank = i + 1,
+            stat = s,
+            metric = "${s.visitCount}",
+            fraction = s.visitCount.toFloat() / max,
+            onOpenHymn = onOpenHymn,
+          )
+        }
+      }
+
+      if (state.topByTime.isNotEmpty()) {
+        item { SectionHeader(title = stringResource(R.string.insights_longest)) }
+        val max = state.topByTime.maxOf { it.totalTimeMs }.coerceAtLeast(1)
+        itemsIndexed(state.topByTime, key = { _, it -> "time-${it.number}-${it.lang}" }) { i, s ->
+          StatBar(
+            rank = i + 1,
+            stat = s,
+            metric = formatDuration(s.totalTimeMs),
+            fraction = s.totalTimeMs.toFloat() / max,
+            onOpenHymn = onOpenHymn,
+          )
+        }
+      }
+
+      if (state.themes.isNotEmpty()) {
+        item {
+          SectionHeader(title = stringResource(R.string.insights_themes))
+          Row(
+            horizontalArrangement = Arrangement.spacedBy(Space.xs),
+            modifier = Modifier
+              .fillMaxWidth()
+              .padding(horizontal = Space.md),
+          ) {
+            state.themes.take(3).forEach { theme ->
+              InfoPill(text = "${theme.categoryName} · ${theme.visitCount}")
+            }
+          }
+        }
+      }
+
+      item {
+        Button(
+          onClick = onYearInHymns,
+          shape = PillShape,
+          modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Space.md, vertical = Space.lg),
+        ) {
+          Text(stringResource(R.string.insights_wrapped_cta))
+        }
+      }
     }
   }
 }
 
 @Composable
-private fun SectionTitle(text: String) {
-  Text(
-    text = text,
-    style = MaterialTheme.typography.titleMedium,
-    fontWeight = FontWeight.SemiBold,
-    modifier = Modifier.padding(top = 20.dp, bottom = 8.dp),
+private fun StatBar(
+  rank: Int,
+  stat: HymnStat,
+  metric: String,
+  fraction: Float,
+  onOpenHymn: (Int) -> Unit,
+) {
+  RankedBarRow(
+    rank = rank,
+    title = stat.title,
+    supporting = "#${stat.number} · ${stat.categoryName}",
+    metric = metric,
+    fraction = fraction,
+    onClick = { onOpenHymn(stat.number) },
+    modifier = Modifier.padding(horizontal = Space.md, vertical = Space.xxs),
   )
 }
 
-@Composable
-private fun StatRow(stat: HymnStat, metric: String, onOpen: (Int) -> Unit) {
-  Column(
-    modifier = Modifier
-      .fillMaxWidth()
-      .clickable { onOpen(stat.number) }
-      .padding(vertical = 6.dp),
-  ) {
-    Text("#${stat.number}  ${stat.title}", fontWeight = FontWeight.Medium)
-    Text(metric, style = MaterialTheme.typography.bodySmall)
-  }
-}
-
-private fun formatDuration(ms: Long): String {
+internal fun formatDuration(ms: Long): String {
   val minutes = TimeUnit.MILLISECONDS.toMinutes(ms)
   val hours = minutes / 60
   val rem = minutes % 60

--- a/app/src/main/java/net/techandgraphics/hymn/ui/screen/wrapped/YearInHymnsScreen.kt
+++ b/app/src/main/java/net/techandgraphics/hymn/ui/screen/wrapped/YearInHymnsScreen.kt
@@ -1,118 +1,252 @@
 package net.techandgraphics.hymn.ui.screen.wrapped
 
 import android.content.Intent
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Share
+import androidx.compose.material.icons.rounded.Star
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import net.techandgraphics.hymn.R
 import net.techandgraphics.hymn.domain.model.YearInHymnsReport
+import net.techandgraphics.hymn.ui.components.EmptyState
+import net.techandgraphics.hymn.ui.theme.PillShape
+import net.techandgraphics.hymn.ui.theme.Space
 import java.util.concurrent.TimeUnit
 
+private data class WrappedSlide(
+  val kicker: String,
+  val headline: String,
+  val detail: String,
+)
+
+/**
+ * The year-in-review story. Slides are typed rather than raw newline-delimited
+ * strings, which lets each one set a real typographic hierarchy — kicker,
+ * headline, detail — instead of one centred paragraph.
+ */
 @Composable
 fun YearInHymnsScreen(
   state: WrappedUiState,
   onClose: () -> Unit,
 ) {
   val report = state.report
+
   if (state.loading) {
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-      Text("Gathering your year…")
-    }
-    return
-  }
-  if (report == null || report.summary.totalVisits == 0L) {
-    Column(
-      modifier = Modifier
-        .fillMaxSize()
-        .padding(24.dp),
-      verticalArrangement = Arrangement.Center,
-      horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-      Text("Not enough reading yet for this year.", textAlign = TextAlign.Center)
-      TextButton(onClick = onClose) { Text("Close") }
-    }
-    return
-  }
-
-  val slides = buildSlides(report)
-  val pagerState = rememberPagerState { slides.size }
-  val context = LocalContext.current
-
-  Column(modifier = Modifier.fillMaxSize()) {
-    TextButton(onClick = onClose, modifier = Modifier.padding(8.dp)) { Text("Close") }
-    HorizontalPager(
-      state = pagerState,
-      modifier = Modifier.weight(1f),
-    ) { page ->
-      Box(
-        modifier = Modifier
-          .fillMaxSize()
-          .background(MaterialTheme.colorScheme.surface)
-          .padding(24.dp),
-        contentAlignment = Alignment.Center,
-      ) {
+      Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        CircularProgressIndicator()
+        Spacer(Modifier.height(Space.md))
         Text(
-          text = slides[page],
-          style = MaterialTheme.typography.headlineSmall,
-          textAlign = TextAlign.Center,
-          fontWeight = FontWeight.Medium,
+          text = stringResource(R.string.wrapped_loading),
+          style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
       }
     }
-    Button(
-      onClick = {
-        val shareText = buildShareText(report)
-        context.startActivity(
-          Intent.createChooser(
-            Intent(Intent.ACTION_SEND).apply {
-              type = "text/plain"
-              putExtra(Intent.EXTRA_TEXT, shareText)
-            },
-            "Share your Year in Hymns",
+    return
+  }
+
+  if (report == null || report.summary.totalVisits == 0L) {
+    Box(Modifier.fillMaxSize()) {
+      EmptyState(
+        icon = Icons.Rounded.Star,
+        title = stringResource(R.string.wrapped_empty_title),
+        message = stringResource(R.string.wrapped_empty_message),
+        action = {
+          Button(onClick = onClose, shape = PillShape) {
+            Text(stringResource(R.string.action_close))
+          }
+        },
+      )
+    }
+    return
+  }
+
+  val slides = remember(report) { buildSlides(report) }
+  val pagerState = rememberPagerState { slides.size }
+  val context = LocalContext.current
+
+  // The gradient is painted from `primary`/`tertiary`, which are light tones in
+  // dark mode. Hard-coding white text on top left the story nearly unreadable
+  // there, so all content colours come off `onPrimary` and flip with the theme.
+  val onStory = MaterialTheme.colorScheme.onPrimary
+
+  Box(modifier = Modifier.fillMaxSize()) {
+    HorizontalPager(state = pagerState, modifier = Modifier.fillMaxSize()) { page ->
+      Box(
+        modifier = Modifier
+          .fillMaxSize()
+          .background(
+            Brush.linearGradient(
+              listOf(
+                MaterialTheme.colorScheme.primary,
+                MaterialTheme.colorScheme.tertiary,
+              ),
+            ),
           )
-        )
-      },
+          .padding(Space.xl),
+        contentAlignment = Alignment.Center,
+      ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+          Text(
+            text = slides[page].kicker.uppercase(),
+            style = MaterialTheme.typography.labelMedium,
+            color = onStory.copy(alpha = 0.8f),
+            textAlign = TextAlign.Center,
+          )
+          Spacer(Modifier.height(Space.sm))
+          Text(
+            text = slides[page].headline,
+            style = MaterialTheme.typography.displaySmall,
+            color = onStory,
+            textAlign = TextAlign.Center,
+          )
+          if (slides[page].detail.isNotBlank()) {
+            Spacer(Modifier.height(Space.sm))
+            Text(
+              text = slides[page].detail,
+              style = MaterialTheme.typography.titleMedium,
+              color = onStory.copy(alpha = 0.9f),
+              textAlign = TextAlign.Center,
+            )
+          }
+        }
+      }
+    }
+
+    IconButton(
+      onClick = onClose,
       modifier = Modifier
-        .fillMaxWidth()
-        .padding(16.dp),
+        .align(Alignment.TopEnd)
+        .padding(Space.xs),
     ) {
-      Text("Share")
+      Icon(
+        imageVector = Icons.Rounded.Close,
+        contentDescription = stringResource(R.string.action_close),
+        tint = onStory,
+      )
+    }
+
+    Column(
+      horizontalAlignment = Alignment.CenterHorizontally,
+      modifier = Modifier
+        .align(Alignment.BottomCenter)
+        .fillMaxWidth()
+        .padding(Space.md),
+    ) {
+      Row(horizontalArrangement = Arrangement.spacedBy(Space.xxs)) {
+        repeat(slides.size) { index ->
+          val color by animateColorAsState(
+            if (index == pagerState.currentPage) onStory
+            else onStory.copy(alpha = 0.35f),
+            label = "wrappedDot",
+          )
+          Box(
+            modifier = Modifier
+              .size(8.dp)
+              .clip(PillShape)
+              .background(color),
+          )
+        }
+      }
+      Spacer(Modifier.height(Space.md))
+      Button(
+        onClick = {
+          context.startActivity(
+            Intent.createChooser(
+              Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_TEXT, buildShareText(report))
+              },
+              context.getString(R.string.wrapped_share_title),
+            ),
+          )
+        },
+        shape = PillShape,
+        colors = ButtonDefaults.buttonColors(
+          containerColor = onStory,
+          contentColor = MaterialTheme.colorScheme.primary,
+        ),
+        modifier = Modifier.fillMaxWidth(),
+      ) {
+        Icon(Icons.Rounded.Share, contentDescription = null, modifier = Modifier.size(18.dp))
+        Spacer(Modifier.size(Space.xs))
+        Text(stringResource(R.string.action_share))
+      }
     }
   }
 }
 
-private fun buildSlides(report: YearInHymnsReport): List<String> {
+private fun buildSlides(report: YearInHymnsReport): List<WrappedSlide> {
   val minutes = TimeUnit.MILLISECONDS.toMinutes(report.summary.totalTimeMs)
   val topVisit = report.topVisited.firstOrNull()
   val topTime = report.topByTime.firstOrNull()
   val theme = report.topCategories.firstOrNull()
-  val lang = report.languageSplit.entries.joinToString(" · ") { "${it.key.uppercase()}: ${it.value}" }
-  return listOf(
-    "Your Year in Hymns\n${report.year}",
-    "You opened ${report.summary.totalVisits} hymns\nacross ${report.summary.activeDays} days",
-    "You spent about $minutes minutes reading",
-    topVisit?.let { "Most visited\n#${it.number} ${it.title}" } ?: "Keep exploring hymns",
-    topTime?.let { "You lingered with\n#${it.number} ${it.title}" } ?: "More time with hymns awaits",
-    theme?.let { "Your theme\n${it.categoryName}" } ?: "Your themes will appear here",
-    if (lang.isNotBlank()) "Languages\n$lang" else "Sing in every tongue you love",
-    "Thank you for reading with Hymn Book\nSwipe back or share your year",
-  )
+  val lang = report.languageSplit.entries.joinToString(" · ") {
+    "${it.key.uppercase()} ${it.value}"
+  }
+
+  return buildList {
+    add(WrappedSlide("Your Year in Hymns", report.year.toString(), "Swipe to begin"))
+    add(
+      WrappedSlide(
+        "You opened",
+        "${report.summary.totalVisits} hymns",
+        "across ${report.summary.activeDays} days",
+      ),
+    )
+    add(WrappedSlide("Time spent reading", "$minutes min", ""))
+    if (topVisit != null) {
+      add(WrappedSlide("Most visited", topVisit.title, "#${topVisit.number}"))
+    }
+    if (topTime != null) {
+      add(WrappedSlide("You lingered with", topTime.title, "#${topTime.number}"))
+    }
+    if (theme != null) {
+      add(WrappedSlide("Your theme", theme.categoryName, "${theme.visitCount} opens"))
+    }
+    if (lang.isNotBlank()) {
+      add(WrappedSlide("Languages", lang, ""))
+    }
+    add(
+      WrappedSlide(
+        "Thank you for reading",
+        "See you next year",
+        "Share your year below",
+      ),
+    )
+  }
 }
 
 private fun buildShareText(report: YearInHymnsReport): String {


### PR DESCRIPTION
## Summary
Polishes Insights (Stats) and Year in Hymns to the shared mockup. Mockup Settings and reset-stats already shipped with the shell PR (#277).

## Changes
- **ui**
  - Insights screen cards / period control / rankings polish
  - Year in Hymns story slides polish

## Technical notes
- Settings portion of #275 landed in #277; this finishes Insights/Wrapped
- Accent remains `#D35500`

## Test plan
- [x] `./gradlew :app:compileDevKotlin`
- [ ] Manual: Insights week/year, Year in Hymns slides

Closes #275